### PR TITLE
Try to use stdin as a message source when arguments missing

### DIFF
--- a/bin/cowsay
+++ b/bin/cowsay
@@ -2,5 +2,9 @@
 
 require 'cowsay'
 
-message = ARGV.join(' ')
+message = if ARGV.any?
+  ARGV.join(' ')
+else
+  ARGF.read.chomp
+end
 puts Cowsay.say message


### PR DESCRIPTION
It allows us to use cowsay via pipe

``` bash
date | cowsay
```

Instead of

```
cowsay `date`
```

as in original perl version of cowsay
